### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
 APP := bruce
 APP_ENTRY := cmd/main.go
 SHELL := /bin/bash
-VER := source
+VER := $(shell git rev-parse --short HEAD)
 ifndef VER
-$(error BUILD_VER not set: Run make this way: `make VER=1.0.31`)
+$(error VER not set: Run make this way: `make VER=1.0.31`)
 endif
 ROOTPATH := $(shell echo ${PWD})
+ARCH := $(shell uname -m)
+OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 
 .PHONY: all clean setup build deploy run
 
@@ -22,13 +24,14 @@ package: build zipit
 
 deploy: build-local push
 
-build: clean setup build-local
+build: clean setup build-local 
 
 build-local:
 	@go version
 	@go get ./cmd/...
-	GOOS=linux GOARCH=amd64 go build -ldflags "-s -w -X main.version=${VER}" -o ${ROOTPATH}/.build/bin/$(APP) ${APP_ENTRY}
+	GOOS=${OS} GOARCH=${ARCH} go build -ldflags "-s -w -X main.version=${VER}" -o ${ROOTPATH}/.build/bin/${APP}-${OS}-${ARCH} ${APP_ENTRY}
+
 
 zipit:
-	cd .build/ && zip -r ${APP}-${VER}-${UNAME}.zip ./*
+	cd .build/ && zip -r ${APP}-${VER}-${OS}-${ARCH}.zip ./*
 	@echo "package ready under: .build/"


### PR DESCRIPTION
# Pull Request

Thank you for your contribution! Please ensure the following checklist is complete before submitting your pull request.

---

## Summary

Provide a short summary of the changes introduced by this pull request. Highlight the main purpose and any key features or bug fixes:

- **Type of Change** (select one):
  - [ ] Bug fix
  - [ ] New feature
  - [ ] Documentation update
  - [x] Other (describe): Update the Makefile to discover the OS/HW type (not tested on Windows). Also added a short commit hash when zipping up the tree.

---

## Related Issues

No related issues

---

## Changes Introduced

- Changed the Makefile to look at the OS/ARCH and set those variables as well as setting a VER for the build - as a short hash. Mostly because I'm lazy and am testing on a Mac silicon box. Also did a simply rev-parse on the branch and added that value to the zip file and VER (if you want to quickly play with a specific branch for testing, etc. - may not be useful)

---

## Testing Instructions

I did a simple test to validate that the variable overloads still worked

```bash
make VER=1.1.1
rm -rf /Users/XXXXX/repos/bruce/.build/
rm -rf /Users/XXXXX/repos/bruce/vendor/
mkdir -p /Users/XXXXX/repos/bruce/.build/bin
go version go1.23.3 darwin/arm64
GOOS=darwin GOARCH=arm64 go build -ldflags "-s -w -X main.version=1.1.1" -o /Users/XXXXX/repos/bruce/.build/bin/bruce-darwin-arm64 cmd/main.go

.build/bin/bruce-darwin-arm64 version
BRUCE version: 1.1.1
Latest version: v1.4.8
```

```bash
make package OS=linux ARCH=amd64
rm -rf /Users/XXXXX/repos/bruce/.build/
rm -rf /Users/XXXXX/repos/bruce/vendor/
mkdir -p /Users/XXXXX/repos/bruce/.build/bin
go version go1.23.3 darwin/arm64
GOOS=linux GOARCH=amd64 go build -ldflags "-s -w -X main.version=de8baa9" -o /Users/XXXXX/repos/bruce/.build/bin/bruce-linux-amd64 cmd/main.go
cd .build/ && zip -r bruce-de8baa9-linux-amd64.zip ./*
  adding: bin/ (stored 0%)
  adding: bin/bruce-linux-amd64 (deflated 66%)
package ready under: .build/

file .build/bin/bruce-linux-amd64
.build/bin/bruce-linux-amd64: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=jAB61TIfNmN-DvdSyV-z/2MuYUKHRDozjGvMGn-JU/Go9K-nH1AKdF_P8X6hnj/k-GjqC3Z3rKs7L7FeDyq, stripped
```

```bash
make package
rm -rf /Users/XXXXX/repos/bruce/.build/
rm -rf /Users/XXXXX/repos/bruce/vendor/
mkdir -p /Users/XXXXX/repos/bruce/.build/bin
go version go1.23.3 darwin/arm64
GOOS=darwin GOARCH=arm64 go build -ldflags "-s -w -X main.version=de8baa9" -o /Users/XXXXX/repos/bruce/.build/bin/bruce-darwin-arm64 cmd/main.go
cd .build/ && zip -r bruce-de8baa9-darwin-arm64.zip ./*
  adding: bin/ (stored 0%)
  adding: bin/bruce-darwin-arm64 (deflated 68%)
package ready under: .build/
```

```bash
make build OS=linux ARCH=amd64
GOOS=linux GOARCH=amd64 go build -ldflags "-s -w -X main.version=de8baa9" -o /Users/XXXXX/repos/bruce/.build/bin/bruce-linux-amd64 cmd/main.go
```
---

## Checklist

Please ensure the following is true before submitting:

- [x] Code compiles without errors.
- [ ] Tests pass successfully.
- [ ] Documentation has been updated (if applicable).
- [ ] Changes adhere to the project’s coding standards.
- [ ] Related issues are referenced (if any).

---

## Screenshots (Optional)

Include screenshots or relevant visuals if applicable to illustrate changes.

---

## Additional Notes

Add any additional context, notes, or considerations for reviewers:

---

Thank you for your contribution! 🚀
