### PR TITLE
[eventic-autofix] ci: modernize GitHub Actions versions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,11 +41,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -59,7 +59,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -72,6 +72,6 @@ jobs:
     #     ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,17 +14,17 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - run: git fetch --force --tags
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v6
         with:
           go-version: '>=1.23.1'
           cache: true
       # More assembly might be required: Docker logins, GPG, etc. It all depends
       # on your needs.
-      - uses: goreleaser/goreleaser-action@v2
+      - uses: goreleaser/goreleaser-action@v6
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro':
           distribution: goreleaser

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - run: git fetch --force --tags
@@ -24,7 +24,7 @@ jobs:
           cache: true
       # More assembly might be required: Docker logins, GPG, etc. It all depends
       # on your needs.
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@v7
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro':
           distribution: goreleaser


### PR DESCRIPTION
Automated GitHub Actions modernization, opened while handling the push of Dependabot bump #167 (`golang.org/x/crypto` 0.51.0→0.52.0) to `main`. The mandatory workflow drift scan found both workflows pinned to outdated/retired action majors. No application code changes — only `.github/workflows/*` action refs.

## Low-risk first-party bumps (pinned to latest major)
- `actions/checkout` v3 → **v6** (go.yml, codeql.yml)
- `actions/setup-go` v3 → **v6** (go.yml)

## Known-breaking — review before merge
- `github/codeql-action` {init,autobuild,analyze} v2 → **v4** (codeql.yml). **v2 is retired** — runs on it now fail; v3/v4 require a newer Node runtime on the runner. The CodeQL job on this PR exercises the new version.
- `goreleaser/goreleaser-action` v2 → **v7** (go.yml — **release tooling**). Spans several majors: v3 made `distribution` + `version` required inputs (both already set here), v4–v6 adjusted defaults/caching, v6+ require Go 1.21+ / Node 20. The `release --clean` invocation and `GITHUB_TOKEN` env are unchanged. This action only runs on a tag push, so it is **not exercised by this PR's CI** — please confirm behavior on the next release.

Both workflows run on `ubuntu-latest` (GitHub-hosted), so the `checkout@v6` self-hosted-runner git-auth regression seen elsewhere on the fleet does not apply here.

Not auto-merged (contains known-breaking majors). Review and merge at your discretion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)