### PR TITLE
ci: scope goreleaser release to tags and migrate config to v2 schema

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,7 +2,6 @@ name: Go
 
 on:
   push:
-    branches: [ main ]
     tags:
       - '*'
 permissions:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,4 @@
+version: 2
 project_name: bruce
 builds:
   - main: ./cmd/


### PR DESCRIPTION
## What changed
- **.github/workflows/go.yml**: removed `branches: [ main ]` from the `on: push:` trigger, leaving `tags: ['*']`. The release now runs only on tag pushes.
- **.goreleaser.yaml**: added `version: 2` at the top of the file to satisfy the goreleaser v2 schema.

## Root cause (from PR #168)
PR #168 bumped `goreleaser/goreleaser-action` from v2 to v7. The v7 action installs the **goreleaser v2.x binary**. The "Go" workflow ran `goreleaser release --clean` on **every push to main** (`on: push: branches: [main]`). Under the v2 binary, `release` on a plain main push fails with `git tag vX was not made against commit ...` because there is no release tag at HEAD. Result: push-to-main CI went red. Additionally `.goreleaser.yaml` used the deprecated `version: 0` schema, which the v2 binary flags.

## Approach chosen and why
The `goreleaser` job is the **only** job in this workflow, and the trigger is workflow-level `on: push`. There is no separate build/test/lint job to preserve. Per the two documented options, the correct fix here is to **remove `branches: [main]` from the trigger** so the workflow runs only on tag pushes — the actual release path. A job-level `if: startsWith(github.ref, 'refs/tags/')` guard was considered but would leave the workflow firing (and immediately skipping) on every main push with no useful work; removing the branch trigger is cleaner and keeps push-to-main green because no non-release CI lives in this workflow.

## Validation
`goreleaser check` run via the official `goreleaser/goreleaser:latest` image (**v2.16.0**, the same v2.x line the v7 action installs):
```
  • checking                                  path=.goreleaser.yaml
  • 1 configuration file(s) validated
  • thanks for using GoReleaser!
EXIT=0
```
Both YAML files also parse cleanly (verified with a YAML loader).

## Note on full validation
The release path itself can only be fully validated by the **USER cutting a tag** (which triggers the workflow on `refs/tags/*` and exercises the actual `goreleaser release --clean` run). The autofix handler **cannot cut tags or trigger releases** by guardrail, so that final end-to-end confirmation is left to the user.

Eventic-Task: 019e797f-0cde-72b1-be47-55d82f3c370e